### PR TITLE
Cleanup and refinement

### DIFF
--- a/demo/demo1_basic_map.py
+++ b/demo/demo1_basic_map.py
@@ -1,0 +1,5 @@
+src = [x for x in range(10)]
+def func(v):
+    return v*10
+
+print map(func, src)

--- a/demo/demo2_basic_qmmap.py
+++ b/demo/demo2_basic_qmmap.py
@@ -1,0 +1,18 @@
+# assumes mongodb running locally, database named 'test', function input is a
+# pymongo object
+import sys, os
+PYBASE = os.path.abspath(os.path.join(os.path.dirname(__file__), "..") ) 
+sys.path.append(PYBASE)
+import pymongo
+from qmmap import mmap
+
+db = pymongo.MongoClient().test
+
+for i in range(10):
+    db.qmmap_in.save({'_id': i})
+
+def func(source):
+    return {'_id': source['_id']*10}
+
+ret = mmap(func, "qmmap_in", "qmmap_out")
+print list(ret.find())

--- a/demo/demo3_mongoengine_qmmap.py
+++ b/demo/demo3_mongoengine_qmmap.py
@@ -1,0 +1,37 @@
+# assumes mongodb running locally, database named 'test', function input is a
+# pymongo object
+
+import sys, os
+PYBASE = os.path.abspath(os.path.join(os.path.dirname(__file__), "..") ) 
+sys.path.append(PYBASE)
+
+from mongoengine import Document, IntField, connect
+import pymongo 
+
+from qmmap import toMongoEngine, connectMongoEngine, mmap
+
+
+connect("test")
+
+class qmmap_in(Document):
+    num = IntField(primary_key = True)
+
+class qmmap_out(Document):
+    val = IntField(primary_key = True)
+
+def init(source, dest):
+    connectMongoEngine(dest)
+
+def func(source):
+    gs = toMongoEngine(source, qmmap_in)
+    gd = qmmap_out(val = gs.num * 10)
+    return gd.to_mongo()
+
+db = pymongo.MongoClient().test
+for i in range(10):
+    db.qmmap_in.save({'_id': i})
+
+ret = mmap(func, "qmmap_in", "qmmap_out")
+
+for o in qmmap_out.objects:
+    print o.val,

--- a/demo/demo4_mongoengine_multicore_qmmap.py
+++ b/demo/demo4_mongoengine_multicore_qmmap.py
@@ -1,0 +1,40 @@
+# assumes mongodb running locally, database named 'test', function input is a
+# pymongo object
+
+import sys, os
+PYBASE = os.path.abspath(os.path.join(os.path.dirname(__file__), "..") ) 
+sys.path.append(PYBASE)
+
+import pymongo
+from mongoengine import Document, IntField, connect
+
+from qmmap import toMongoEngine, connectMongoEngine, mmap
+
+
+connect("test")
+
+class qmmap_in(Document):
+    num = IntField(primary_key = True)
+    extra = IntField()
+
+class qmmap_out(Document):
+    val = IntField(primary_key = True)
+    comp = IntField()
+
+def init(source, dest):
+    connectMongoEngine(dest)
+
+def func(source):
+    gs = toMongoEngine(source, qmmap_in)
+    times10 = gs.num * 10
+    gd = qmmap_out(val=times10, comp=times10 + gs.extra)
+    return gd.to_mongo()
+
+db = pymongo.MongoClient().test
+for i in range(10):
+    db.qmmap_in.save({'_id': i, 'extra': i + 1})
+
+ret = mmap(func, "qmmap_in", "qmmap_out", multi=2, sleep=2, reset=True)
+
+for o in qmmap_out.objects:
+    print o.val, o.comp

--- a/qmcli.py
+++ b/qmcli.py
@@ -73,6 +73,17 @@ one collection into other by use of a function.
         "parameters; overrides any specified from the command line or via " \
         "--jsonconfig"
     )
+    par.add_argument("--key", type=str, default="_id", help=
+        "Key/field to use for chunking; when setting up chunks, this will ensure" \
+        "that no two input documents with the same value for `key` will be placed" \
+        "in different chunks; default: _id (primary key)"
+    )
+    par.add_argument("--sort", type=str, default="_id", help=
+        "Key/field to sort by *within* each chunk; this ensures that, when a " \
+        "chunk is processed, the items will be processed in ascending order by" \
+        "`sort` key (put a '-' in front to sort descending e.g. '-name'); " \
+        "default: _id"
+    )
     par.add_argument("module", help=
         "Python module containing the function you wish to apply to the input " \
         "collection, e.g. foo.bar[...]"

--- a/qmcli.py
+++ b/qmcli.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
+from bson.json_util import loads
 import importlib
 import json
 import os
@@ -126,7 +127,7 @@ one collection into other by use of a function.
     del arg_dict['pyconfig']
     del arg_dict['jsonconfig']
     # Convert query to python dict
-    arg_dict['query'] = json.loads(arg_dict['query'])
+    arg_dict['query'] = loads(arg_dict['query'])
     qmmap.mmap(**arg_dict)
 
 

--- a/qmcli.py
+++ b/qmcli.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+
+import argparse
+import importlib
+import json
+import os
+import sys
+
+import qmmap
+
+
+def main():
+    par = argparse.ArgumentParser(description="""
+Command line wrapper for QMmap utility, which distributes the work of processing
+one collection into other by use of a function.
+""")
+    par.add_argument("--verbose", type=int, default = 1, help=
+        "How much debugging info: 1, 2, or 3 (default=1)"
+    )
+    par.add_argument("--multi", type=int, default = None, help=
+        "How many subprocesses to spawn on this node for this job; affects " \
+        "chunking of housekeeping collection"
+    )
+    par.add_argument("--reset", action='store_true', help=
+        "Drop output collection during housekeeping setup stage"
+    )
+    par.add_argument("--init_only", action='store_true', help=
+        "Only set up housekeeping collection (optionall drop output collection)"
+    )
+    par.add_argument("--process_only", action='store_true', help=
+        "Only run the processing stage of QMmap: query Housekeeping for " \
+        "available chunks and process them"
+    )
+    par.add_argument("--manage_only", action='store_true', help=
+        "Only run the 'manage' stage of QMmap: report progress and reopen chunks" \
+        "being processed if they have taken longer than `timeout` seconds"
+    )
+    par.add_argument("--source_uri", default="mongodb://127.0.0.1/test", help=
+        "URI to the input DB, in MongoDB format:\n" \
+        "mongodb://[username:password@]host[:port]/database"
+    )
+    par.add_argument("--dest_uri", default="mongodb://127.0.0.1/test", help=
+        "URI to the output DB, in MongoDB format:\n" \
+        "mongodb://[username:password@]host[:port]/database"
+    )
+    par.add_argument("--chunk_size", type=int, default=None, help=
+        "Specify CHUNK_SIZE as the size of each chunk; default is to compute" \
+        "based on QMmap's algorithm based on input collection size and number" \
+        "of processes"
+    )
+    par.add_argument("--timeout", type=int, default=120, help=
+        "How long, in seconds, to allow a processor to work on a chunk before " \
+        "assuming it has died and should be released for other processes to work " \
+        "on it; default = 120 seconds"
+    )
+    par.add_argument("--sleep", type=float, default=60, help=
+        "Report status of the job every SLEEP seconds; default = 60"
+    )
+    par.add_argument("--query", type=str, default="{}", help=
+        "Query to restrict what values of the input collection to operate on; " \
+        "default = {} (i.e. all of it)"
+    )
+    par.add_argument("--init", type=str, default=None, help=
+        "String indicating the function in `module` to run on each chunk before " \
+        "processing it; default = None (no such function)"
+    )
+    par.add_argument("--jsonconfig", type=str, default=None, help=
+        "Path to JSON file for specifying this utility's parameters; overrides " \
+        "any which were specified from the command line"
+    )
+    par.add_argument("--pyconfig", type=str, default=None, help=
+        "Python module (e.g. foo.bar[...] which specifies this utility's " \
+        "parameters; overrides any specified from the command line or via " \
+        "--jsonconfig"
+    )
+    par.add_argument("module", help=
+        "Python module containing the function you wish to apply to the input " \
+        "collection, e.g. foo.bar[...]"
+    )
+    par.add_argument("function", help=
+        "Function within `module` that you wish to apply to each member of the" \
+        "input collection"
+    )
+    par.add_argument("source_col", help=
+        "input/source collection, sent to `module`.`function` for processing"
+    )
+    par.add_argument("dest_col", help=
+        "output/destination collection to write output documents of " \
+        "`module`.`function` to"
+    )
+    clargs = par.parse_args()
+    sys.path.insert(0, os.getcwd())
+    module = importlib.import_module(clargs.module)
+    cb = getattr(module, clargs.function)
+    arg_dict = vars(clargs)
+    arg_dict['cb'] = cb
+    del arg_dict['function']
+    # If user has specified a config file, overwrite arg_dict values to the given
+    # ones
+    if clargs.jsonconfig:
+        with open(clargs.jsonconfig, "r") as f:
+            config_dict = json.loads(f.read())
+        arg_dict.update(config_dict)
+    if clargs.pyconfig:
+        configmod = importlib.import_module(clargs.pyconfig)
+        config_dict = {
+            x: y for x, y in vars(configmod).iteritems() if not x.startswith("__")
+        }
+        arg_dict.update(config_dict)
+    if clargs.init:
+        init_fn = getattr(module, clargs.init)
+        arg_dict['init'] = init_fn
+    # Remove the parsed params that aren't handled by qmmap.mmap
+    del arg_dict['module']
+    del arg_dict['pyconfig']
+    del arg_dict['jsonconfig']
+    # Convert query to python dict
+    arg_dict['query'] = json.loads(arg_dict['query'])
+    qmmap.mmap(**arg_dict)
+
+
+if __name__ == "__main__":
+    main()

--- a/qmmap.py
+++ b/qmmap.py
@@ -10,6 +10,7 @@ import threading
 import mongoengine as meng
 from mongoengine.context_managers import switch_collection
 
+MAX_CHUNK_SIZE = 600  # Overall limit
 NULL = open(os.devnull, "w")
 
 def is_shell():
@@ -138,6 +139,7 @@ using one and which to avoid collisions
     if not _is_okay_to_work_on(hkstart):
         return -1
     bulk = dest.initialize_unordered_bulk_op()
+    src.batch_size(MAX_CHUNK_SIZE)
     for doc in src:
         try:
             ret = proc(doc)
@@ -236,14 +238,14 @@ given state
 
 # balance chunk size vs async efficiency etc
 # min 10 obj per chunk
-# max 600 obj per chunk
+# max MAX_CHUNK_SIZE obj per chunk
 # otherwise try for at least 10 chunks per proc
 #
 def _calc_chunksize(count, multi):
     cs = count/(multi*10.0)
 #     if verbose & 2: print "\ninitial size:", cs
     cs = max(cs, 10)
-    cs = min(cs, 600)
+    cs = min(cs, MAX_CHUNK_SIZE)
     if count / float(cs * multi) < 1.0:
         cs *= count / float(cs * multi)
         cs = max(1, int(cs))

--- a/qmmap.py
+++ b/qmmap.py
@@ -282,6 +282,7 @@ def mmap(   cb,
             source_col,
             dest_col,
             init=None, 
+            reset=False,
             source_uri="mongodb://127.0.0.1/test", 
             dest_uri="mongodb://127.0.0.1/test",
             query={},
@@ -324,6 +325,10 @@ def mmap(   cb,
             computed_chunk_size = _calc_chunksize(
                 dbs[source_col].count(), multi, chunk_size)
             if verbose & 2: print "chunk size:", chunk_size
+            if reset:
+                print >> sys.stderr, ("Dropping all records in destination db" +
+                    "/collection {0}/{1}").format(dbd, dest.name)
+                dest.remove({})
             _init(dbs[source_col], dest, key, query, computed_chunk_size, verbose)
         # Now process code, if one of the other "only_" options isn't turned on
         if not manage_only and not init_only:

--- a/qmmap.py
+++ b/qmmap.py
@@ -393,11 +393,11 @@ def _print_progress():
             ttot = tdone*tot / done
             trem = ttot - tdone
             print "%s still waiting: %d out of %d complete (%.3f%%). %.3f seconds complete, %.3f remaining (%.5f hours)" \
-            % (datetime.datetime.now().strftime("%H:%M:%S:%f"), done, tot, pdone, tdone, trem, trem / 3600.0)
+            % (datetime.datetime.utcnow().strftime("%H:%M:%S:%f"), done, tot, pdone, tdone, trem, trem / 3600.0)
         else:
             print "No progress data yet"
     else:
-        print "%s still waiting; nothing done so far" % (datetime.datetime.now(),)
+        print "%s still waiting; nothing done so far" % (datetime.datetime.utcnow(),)
 sys.stdout.flush()
 
 
@@ -417,7 +417,7 @@ def manage(timeout, sleep=120):
         _print_progress()
         # Now, iterate over state=working jobs, restart ones that have gone
         # on longer than the timeout param
-        tnow = datetime.datetime.now()  # get time once instead of repeating
+        tnow = datetime.datetime.utcnow()  # get time once instead of repeating
         # Iterate through working objects to see if it's too long
         hkwquery = [h for h in housekeep.objects(state='working').all()]
         for hkw in hkwquery:

--- a/qmmap.py
+++ b/qmmap.py
@@ -2,6 +2,8 @@
 # mongo Operations
 #
 import sys, os, importlib, datetime, time, traceback, __main__
+import socket
+
 import pymongo
 import threading
 import mongoengine as meng
@@ -15,11 +17,14 @@ def is_shell():
 class housekeep(meng.Document):
     start = meng.DynamicField(primary_key = True)
     end = meng.DynamicField()
-    total = meng.IntField()                             # total # of entries to do
-    good = meng.IntField(default = 0)                   # entries successfully processed
+    total = meng.IntField()  # total # of entries to do
+    good = meng.IntField(default = 0)  # entries successfully processed
 #     bad = meng.IntField(default = 0)                    # entries we failed to process to completion
 #     log = meng.ListField()                              # log of misery -- each item a failed processing incident
     state = meng.StringField(default = 'open')
+    # Globally unique identifier for the process, if any, that is working on
+    # this chunk, to know if something else is working on it
+    procname = meng.StringField(default = 'none')
 #     git = meng.StringField()                                 # git commit of this version of source_destination
     tstart = meng.DateTimeField()  # Time when job started
     time = meng.DateTimeField()  # Time when job finished
@@ -62,9 +67,58 @@ def _init(srccol, destcol, key, query, chunk_size, verbose):
         #get start of next segment
         qq = {'$and': [query, {key: {'$gt': hk.end}}]}
         q = srccol.find(qq, [key]).sort([(key, pymongo.ASCENDING)])
-        tot = q.limit(chunk_size).count()                    #limit count to chunk for speed
+        #limit count to chunk for speed
+        tot = q.limit(chunk_size).count(with_limit_and_skip=True)
 
-def _process(init, proc, src, dest, verbose):
+
+def _is_okay_to_work_on(hkstart):
+    """Returns whether a chunk, identified by its housekeeping start value, is okay
+to work on, i.e. whether its status is "working" and this process is assigned to it
+    """
+    if not hkstart:  # Can ignore if specific chunk not specified
+        return True
+    chunk = housekeep.objects.get(start=hkstart)
+    # If it's been reset to open, or being worked on by another node, no good
+    state = chunk.state
+    if state == "done":
+        print "Chunk {0} is already finished".format(hkstart)
+        sys.stdout.flush()
+        return False
+    if state == "open":
+        print "Chunk {0} had been reset to open".format(hkstart)
+        sys.stdout.flush()
+        return False
+    if state == "working" and chunk.procname != procname():
+        print "Chunk {0} was taken over by {1}, moving on".format(
+            hkstart, chunk.procname)
+        sys.stdout.flush()
+        return False
+    return True
+
+
+def _doc_size(doc):
+    """Returns the size, in bytes of a Mongo object
+    @doc: Mongo document in native Mongo format
+    """
+    return len(bson.BSON.encode(doc))
+
+
+def _write_bulk(bulk):
+    """Execute bulk write `bulk` and note the errors
+    """
+    try:
+        bulk.execute()
+    except:
+        _print_proc("***BULK WRITE EXCEPTION (process)***")
+        _print_proc(traceback.format_exc())
+        _print_proc("***END EXCEPTION***")
+
+
+def _process(init, proc, src, dest, verbose, hkstart=None):
+    """Run process `proc` on cursor `src`.
+    @hkstart: primary key of houskeeping chunk that this is processing, if you are
+using one and which to avoid collisions
+    """
     if not verbose & 1:
         oldstdout = sys.stdout
         sys.stdout = NULL
@@ -72,23 +126,51 @@ def _process(init, proc, src, dest, verbose):
         try:
             init(src, dest)
         except:
-            print >> sys.stderr, "***EXCEPTION (process)***"
-            print >> sys.stderr, traceback.format_exc()
-            print >> sys.stderr, "***END EXCEPTION***"
+            _print_proc("***EXCEPTION (process)***")
+            _print_proc(traceback.format_exc())
+            _print_proc("***END EXCEPTION***")
             return 0
     good = 0
     for doc in src:
+        # On each iteration, check if some other process has taken over; in that
+        # case, exit early with -1
+        if hkstart:  # don't check on jobs that don't use housekeeping
+            chunk = housekeep.objects.get(start=hkstart)
+            # If it's been reset to open, or being worked on by another node, exit
+            if chunk.state == "open":
+                print "Chunk {0} had been reset to open, moving on".format(hkstart)
+                sys.stdout.flush()
+                return -1
+            if chunk.state == "working" and chunk.procname != _procname():
+                print "Chunk {0} was taken over by {1}, moving on".format(
+                    hkstart, chunk.procname)
+                sys.stdout.flush()
+                return -1
         try:
             ret = proc(doc)
+            sys.stdout.flush()
             if ret != None:
                 dest.save(ret)
             good += 1
         except:
-            print >> sys.stderr, "***EXCEPTION (process)***"
-            print >> sys.stderr, traceback.format_exc()
-            print >> sys.stderr, "***END EXCEPTION***"
+            _print_proc("***EXCEPTION (process)***")
+            _print_proc(traceback.format_exc())
+            _print_proc("***END EXCEPTION***")
+    # After processing, check again if okay to insert
+    sys.stdout.flush()
+    if not _is_okay_to_work_on(hkstart):
+        return -1
+    if hkstart:  # Do bulk insert only if doing housekeeping
+        if insert_count > 0:
+            _print_proc(u"Writing to chunk {0} : {1} docs totaling {2} " \
+                u"bytes".format(hkstart, insert_count, insert_size))
+            _write_bulk(bulk)
+        else:
+            _print_proc(u"No bulk writes to do at end of chunk" \
+                u" {0}".format(hkstart))
     if not verbose & 1:
         sys.stdout = oldstdout
+    sys.stdout.flush()
     return good
 
 def do_chunks(init, proc, src_col, dest_col, query, key, verbose):
@@ -100,32 +182,58 @@ def do_chunks(init, proc, src_col, dest_col, query, key, verbose):
                 '$set': {
                     'state': 'working',
                     'tstart': tnow,
+                    'procname': procname(),
                 }
             }
         )
-        #if raw==None, someone scooped us
+        # if raw==None, someone scooped us
         if raw != None:
+            raw_id = raw['_id']
             #reload as mongoengine object -- _id is .start (because set as primary_key)
-            hko = housekeep.objects(start = raw['_id'])[0]
+            hko = housekeep.objects(start = raw_id)[0]
             # Record git commit for sanity
 #             hko.git = git.Git('.').rev_parse('HEAD')
 #             hko.save()
             # get data pointed to by housekeep
             qq = {'$and': [query, {key: {'$gte': hko.start}}, {key: {'$lte': hko.end}}]}
-            cursor = src_col.find(qq)
+            # Make cursor not timeout, using version-appropriate paramater
+            if pymongo.version_tuple[0] == 2:
+                cursor = src_col.find(qq, timeout=False)
+            elif pymongo.version_tuple[0] == 3:
+                cursor = src_col.find(qq, no_cursor_timeout=True)
+            else:
+                raise Exception("Unknown pymongo version")
             if verbose & 2: print "mongo_process: %d elements in chunk %s-%s" % (cursor.count(), hko.start, hko.end)
             sys.stdout.flush()
             # This is where processing happens
             hko.good =_process(init, proc, cursor, dest_col, verbose)
-            hko.state = 'done'
-            hko.time = datetime.datetime.utcnow()
-            hko.save()
-#         else:
-#             if verbose & 2: print "race lost -- skipping"
-#         if verbose & 2: print "sleep..."
-        sys.stdout.flush()
-        time.sleep(0.1)
-#
+            # Check if another job finished it while this one was plugging away
+            hko_later = housekeep.objects(start = raw_id).only('state')[0]
+            if hko.good == -1:  # Early exit signal
+                print "Chunk at %s lost to another process; not updating" % raw_id
+                sys.stdout.flush()
+            elif hko_later.state == 'done':
+                print "Chunk at %s had already finished; not updating" % raw_id
+                sys.stdout.flush()
+            else:
+                hko.state = 'done'
+                hko.procname = 'none'
+                hko.time = datetime.datetime.utcnow()
+                hko.save()
+        else:
+            # Not all done, but none were open for processing; thus, wait to
+            # see if one re-opens
+            print 'Standing by for reopening of "working" job...'
+            time.sleep(60)
+
+
+def _num_not_at_state(state):
+    """Helper for consisely counting the number of housekeeping objects at a
+given state
+    """
+    return housekeep.objects(state__ne=state).count()
+
+
 # balance chunk size vs async efficiency etc
 # min 10 obj per chunk
 # max 600 obj per chunk
@@ -145,6 +253,15 @@ def _calc_chunksize(count, multi):
 #     if verbose & 2: print "chunk count:", count / float(cs)
 #     if verbose & 2: print "per proc:", count / float(cs * multi)
     return int(cs)
+
+
+
+def procname():
+    """Utility for getting a globally-unique process name, which needs to combine
+hostname and process id
+@returns: string with format "<fully qualified hostname>:<process id>"."""
+    return "{0}:{1}".format(socket.getfqdn(), os.getpid())
+
 
 # cs = _calc_chunksize(11, 3)
 # cs = _calc_chunksize(20, 1)
@@ -169,22 +286,25 @@ def mmap(   cb,
             wait_done=True,
             init_only=False,
             process_only=False,
+            manage_only=False,
             timeout=120):
 
     dbs = pymongo.MongoClient(source_uri).get_default_database()
     dbd = pymongo.MongoClient(dest_uri).get_default_database()
     dest = dbd[dest_col]
-    if multi == None:           #don't use housekeeping, run straight process
+    if multi == None:  # don't use housekeeping, run straight process
 
         source = dbs[source_col].find(query)
         _process(init, cb, source, dest, verbose)
     else:
         _connect(dbs[source_col], dest)
-        if not process_only:
+        if manage_only:
+            manage(timeout)
+        elif not process_only:
             chunk_size = _calc_chunksize(dbs[source_col].count(), multi)
             if verbose & 2: print "chunk size:", chunk_size
             _init(dbs[source_col], dest, key, query, chunk_size, verbose)
-        if not init_only:
+        elif not init_only:
             args = (init, cb, dbs[source_col], dest, query, key, verbose)
             if verbose & 2:
                 print "Chunking with arguments %s" % (args,)
@@ -192,12 +312,16 @@ def mmap(   cb,
                 print >> sys.stderr, ("WARNING -- can't generate module name. Multiprocessing will be emulated...")
                 do_chunks(*args)
             else:
-                for j in xrange(multi):
-                    if verbose & 2:
-                        print "Launching subprocess %s" % j
-                    threading.Thread(target=do_chunks, args=args).start()
+                if multi > 1:
+                    for j in xrange(multi):
+                        if verbose & 2:
+                            print "Launching subprocess %s" % j
+                        threading.Thread(target=do_chunks, args=args).start()
+                else:
+                    do_chunks(*args)
             if wait_done:
-                wait(timeout, verbose & 2)
+                manage(timeout)
+                #wait(timeout, verbose & 2)
     return dbd[dest_col]
 
 def toMongoEngine(pmobj, metype):
@@ -229,10 +353,76 @@ def wait(timeout=120, verbose=True):
             if verbose: print >> sys.stderr, "TIMEOUT reached - resetting working chunks to open"
             q = housekeep.objects(state = "working")
             if q:
-                q.update(state = "open")
+                q.update(state="open", procname='none')
         if r != rr:
             t = time.time()
         if verbose: print r, "chunks remaning to be processed; %f seconds left until timeout" % (timeout - (time.time() - t)) 
         time.sleep(1)
         rr = r
         r = remaining()
+
+
+def _print_proc(log_str):
+    """Utility function for writing to STDERR with procname prepended
+    @log_str: string to write
+    """
+    print >> sys.stderr, procname(), log_str
+
+
+def _print_progress():
+    q = housekeep.objects(state = 'done').only('time')
+    tot = housekeep.objects.count()
+    done = q.count()
+    if done > 0:
+        pdone = 100. * done / tot
+        q = q.order_by('time')
+        first = q[0].time
+        q = q.order_by('-time')
+        last = q[0].time
+        if first and last:  # guard against lacking values
+            tdone = float((last-first).seconds)
+            ttot = tdone*tot / done
+            trem = ttot - tdone
+            print "%s still waiting: %d out of %d complete (%.3f%%). %.3f seconds complete, %.3f remaining (%.5f hours)" \
+            % (datetime.datetime.now().strftime("%H:%M:%S:%f"), done, tot, pdone, tdone, trem, trem / 3600.0)
+        else:
+            print "No progress data yet"
+    else:
+        print "%s still waiting; nothing done so far" % (datetime.datetime.now(),)
+sys.stdout.flush()
+
+
+def manage(timeout, sleep=120):
+    """Give periodic status, reopen dead jobs, return success when over;
+    combination of wait, status, clean, and the reprocessing functions.
+    sleep = time (sec) between status updates
+    timeout = time (sec) to give a job until it's restarted
+    """
+    num_not_done = _num_not_at_state('done')
+    print "Managing job's execution; currently {0} remaining".format(num_not_done)
+    sys.stdout.flush()
+    # Keep going until none are state=working or done
+    while _num_not_at_state('done') > 0:
+        # Sleep before management step
+        time.sleep(sleep)
+        _print_progress()
+        # Now, iterate over state=working jobs, restart ones that have gone
+        # on longer than the timeout param
+        tnow = datetime.datetime.now()  # get time once instead of repeating
+        # Iterate through working objects to see if it's too long
+        hkwquery = [h for h in housekeep.objects(state='working').all()]
+        for hkw in hkwquery:
+            # .tstart must have time value for state to equal 'working' at all
+            time_taken = (tnow - hkw.tstart).total_seconds()
+            print (u"Chunk on {0} starting at {1} has been working for {2} " +
+                u"sec").format(hkw.procname, hkw.start, time_taken)
+            sys.stdout.flush()
+            if time_taken > timeout:
+                print (u"More than {0} sec spent on chunk {1} ;" +
+                    u" setting status back to open").format(
+                    timeout, hkw.start)
+                sys.stdout.flush()
+                hkw.state = "open"
+                hkw.procname = 'none'
+                hkw.save()
+    print "----------- PROCESSING COMPLETED ------------"

--- a/qmmap.py
+++ b/qmmap.py
@@ -30,8 +30,8 @@ class housekeep(meng.Document):
     time = meng.DateTimeField()  # Time when job finished
     meta = {'indexes': ['state', 'time']}
 
-def _connect(srccol, destcol):
-    connectMongoEngine(destcol)
+def _connect(srccol, destcol, dest_uri=None):
+    connectMongoEngine(destcol, dest_uri)
     hk_colname = srccol.name + '_' + destcol.name
     switch_collection(housekeep, hk_colname).__enter__()
 
@@ -297,7 +297,7 @@ def mmap(   cb,
         source = dbs[source_col].find(query)
         _process(init, cb, source, dest, verbose)
     else:
-        _connect(dbs[source_col], dest)
+        _connect(dbs[source_col], dest, dest_uri)
         if manage_only:
             manage(timeout)
         elif not process_only:
@@ -329,7 +329,7 @@ def toMongoEngine(pmobj, metype):
     meobj.validate()
     return meobj
 
-def connectMongoEngine(pmcol):
+def connectMongoEngine(pmcol, conn_uri=None):
     if pymongo.version_tuple[0] == 2:     #really? REALLY?
         #host = pmcol.database.connection.HOST
         #port = pmcol.database.connection.PORT
@@ -338,6 +338,9 @@ def connectMongoEngine(pmcol):
     else:
         host = pmcol.database.client.HOST
         port = pmcol.database.client.PORT
+    # Can just use the connection uri, which has credentials
+    if conn_uri:
+        return meng.connect(pmcol.database.name, host=conn_uri)
     return meng.connect(pmcol.database.name, host=host, port=port)
 
 def remaining():

--- a/qmmap.py
+++ b/qmmap.py
@@ -308,7 +308,8 @@ def mmap(   cb,
             chunk_size = _calc_chunksize(dbs[source_col].count(), multi)
             if verbose & 2: print "chunk size:", chunk_size
             _init(dbs[source_col], dest, key, query, chunk_size, verbose)
-        elif not init_only:
+        # Now process code, if one of the other "only_" options isn't turned on
+        if not manage_only and not init_only:
             args = (init, cb, dbs[source_col], dest, query, key, verbose)
             if verbose & 2:
                 print "Chunking with arguments %s" % (args,)

--- a/qmmap.py
+++ b/qmmap.py
@@ -10,7 +10,7 @@ import threading
 import mongoengine as meng
 from mongoengine.context_managers import switch_collection
 
-MAX_CHUNK_SIZE = 600  # Overall limit
+MAX_CHUNK_SIZE = 60  # Overall limit
 NULL = open(os.devnull, "w")
 
 def is_shell():

--- a/qmmap.py
+++ b/qmmap.py
@@ -3,6 +3,7 @@
 #
 import sys, os, importlib, datetime, time, traceback, __main__
 import pymongo
+import threading
 import mongoengine as meng
 from mongoengine.context_managers import switch_collection
 
@@ -174,6 +175,7 @@ def mmap(   cb,
     dbd = pymongo.MongoClient(dest_uri).get_default_database()
     dest = dbd[dest_col]
     if multi == None:           #don't use housekeeping, run straight process
+
         source = dbs[source_col].find(query)
         _process(init, cb, source, dest, verbose)
     else:
@@ -183,16 +185,17 @@ def mmap(   cb,
             if verbose & 2: print "chunk size:", chunk_size
             _init(dbs[source_col], dest, key, query, chunk_size, verbose)
         if not init_only:
+            args = (init, cb, dbs[source_col], dest, query, key, verbose)
+            if verbose & 2:
+                print "Chunking with arguments %s" % (args,)
             if is_shell():
                 print >> sys.stderr, ("WARNING -- can't generate module name. Multiprocessing will be emulated...")
-                do_chunks(init, cb, dbs[source_col], dest, query, key, verbose)
+                do_chunks(*args)
             else:
-                cb_mod = sys.argv[0][:-3]
-                cmd = "python worker.py %s %s %s %s --src_uri='%s' --dest_uri='%s' --init='%s' --query='%s' --key=%s --verbose=%s &" % (cb_mod, cb.__name__, source_col, dest_col,
-                                                                source_uri, dest_uri, init.__name__ if init else '', query, key, verbose)
-                if verbose & 2: print "os.system:", cmd
-                for j in range(multi):
-                    os.system(cmd)
+                for j in xrange(multi):
+                    if verbose & 2:
+                        print "Launching subprocess %s" % j
+                    threading.Thread(target=do_chunks, args=args).start()
             if wait_done:
                 wait(timeout, verbose & 2)
     return dbd[dest_col]
@@ -204,8 +207,10 @@ def toMongoEngine(pmobj, metype):
 
 def connectMongoEngine(pmcol):
     if pymongo.version_tuple[0] == 2:     #really? REALLY?
-        host = pmcol.database.connection.HOST
-        port = pmcol.database.connection.PORT
+        #host = pmcol.database.connection.HOST
+        #port = pmcol.database.connection.PORT
+        host = pmcol.database.connection.host
+        port = pmcol.database.connection.port
     else:
         host = pmcol.database.client.HOST
         port = pmcol.database.client.PORT

--- a/qmmap.py
+++ b/qmmap.py
@@ -5,6 +5,7 @@ import sys, os, importlib, datetime, time, traceback, __main__
 import socket
 
 import pymongo
+from pymongo.read_preferences import ReadPreference
 import threading
 import mongoengine as meng
 from mongoengine.context_managers import switch_collection
@@ -289,7 +290,9 @@ def mmap(   cb,
             manage_only=False,
             timeout=120):
 
-    dbs = pymongo.MongoClient(source_uri).get_default_database()
+    dbs = pymongo.MongoClient(
+        source_uri, read_preference=ReadPreference.SECONDARY_PREFERRED,
+    ).get_default_database()
     dbd = pymongo.MongoClient(dest_uri).get_default_database()
     dest = dbd[dest_col]
     if multi == None:  # don't use housekeeping, run straight process

--- a/qmmap.py
+++ b/qmmap.py
@@ -49,7 +49,7 @@ def _init(srccol, destcol, key, query, chunk_size, verbose):
 # #         if verbose & 2: print "added %d entries to %s" % (q.count(), housekeep._get_collection_name())
 # #         sys.stdout.flush()
     i = 0
-    tot = q.limit(chunk_size).count()
+    tot = q.limit(chunk_size).count(with_limit_and_skip=True)
     while tot > 0:
         if verbose & 2: print "housekeeping: %d" % i
         i +=1

--- a/qmmap.py
+++ b/qmmap.py
@@ -294,7 +294,8 @@ def mmap(   cb,
             manage_only=False,
             chunk_size=None,
             timeout=120,
-            sleep=60):
+            sleep=60,
+            **kwargs):
 
     # Two different connect=False idioms; need to set it false to wait on
     # connecting in case of process being spawned.

--- a/qmmap.py
+++ b/qmmap.py
@@ -174,7 +174,7 @@ using one and which to avoid collisions
     sys.stdout.flush()
     return good
 
-def do_chunks(init, proc, src_col, dest_col, query, key, verbose):
+def do_chunks(init, proc, src_col, dest_col, query, key, verbose, sleep=60):
     while housekeep.objects(state = 'done').count() < housekeep.objects.count():
         tnow = datetime.datetime.utcnow()
         raw = housekeep._collection.find_and_modify(
@@ -226,7 +226,7 @@ def do_chunks(init, proc, src_col, dest_col, query, key, verbose):
             # Not all done, but none were open for processing; thus, wait to
             # see if one re-opens
             print 'Standing by for reopening of "working" job...'
-            time.sleep(60)
+            time.sleep(sleep)
 
 
 def _num_not_at_state(state):
@@ -289,7 +289,8 @@ def mmap(   cb,
             init_only=False,
             process_only=False,
             manage_only=False,
-            timeout=120):
+            timeout=120,
+            sleep=60):
 
     dbs = pymongo.MongoClient(
         source_uri, read_preference=ReadPreference.SECONDARY_PREFERRED,
@@ -303,14 +304,14 @@ def mmap(   cb,
     else:
         _connect(dbs[source_col], dest, dest_uri)
         if manage_only:
-            manage(timeout)
+            manage(timeout, sleep)
         elif not process_only:
             chunk_size = _calc_chunksize(dbs[source_col].count(), multi)
             if verbose & 2: print "chunk size:", chunk_size
             _init(dbs[source_col], dest, key, query, chunk_size, verbose)
         # Now process code, if one of the other "only_" options isn't turned on
         if not manage_only and not init_only:
-            args = (init, cb, dbs[source_col], dest, query, key, verbose)
+            args = (init, cb, dbs[source_col], dest, query, key, verbose, sleep)
             if verbose & 2:
                 print "Chunking with arguments %s" % (args,)
             if is_shell():
@@ -325,7 +326,7 @@ def mmap(   cb,
                 else:
                     do_chunks(*args)
             if wait_done:
-                manage(timeout)
+                manage(timeout, sleep)
                 #wait(timeout, verbose & 2)
     return dbd[dest_col]
 

--- a/qmmap_worker.py
+++ b/qmmap_worker.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 #
 # qmmap worker invoked as command-line script
 #
@@ -6,6 +7,7 @@ from qmmap import do_chunks, connectMongoEngine, housekeep
 from mongoengine.context_managers import switch_collection
 
 par = argparse.ArgumentParser(description = "qmmap worker process")
+par.add_argument("module_abspath")
 par.add_argument("module")
 par.add_argument("function")
 par.add_argument("source")
@@ -21,6 +23,7 @@ config = par.parse_args()
 
 query = json.loads(config.query)
 
+sys.path.insert(0, config.module_abspath)
 module = importlib.import_module(config.module)
 cb = getattr(module, config.function)
 init = getattr(module, config.init) if config.init else None

--- a/readme.MD
+++ b/readme.MD
@@ -6,11 +6,13 @@
 
 QMmap is a lightweight library that enables asynchronous, parallel processing of MongoDB documents using a simple, map-like interface.
 
-*The following examples were created in IPython, an excellent tool. Cut and paste these examples into your IPython notebook:*
+*The following examples were created in IPython, an excellent tool. Cut and paste these examples into your IPython notebook, or run the Python file indicated.*
 
 Python's `map` function takes a callback function and applies it to a list, returning a list:
 
 ```Python
+# demo/demo1_basic_map.py
+
 src = [x for x in range(10)]
 def func(v):
     return v*10
@@ -25,8 +27,10 @@ print map(func, src)
 QMmap provides a similar function, ```mmap```, that operates on MongoDB collections:
 
 ```Python
+# demo/demo2_basic_qummap.py
 # assumes mongodb running locally, database named 'test', function input is a
 # pymongo object
+
 import pymongo
 from qmmap import mmap
 
@@ -46,8 +50,10 @@ print list(ret.find())
 QMmap has helper functions to support mongoengine classes:
 
 ```Python
+# demo/demo3_mongoengine_qmmap.py
+
 from mongoengine import Document, IntField, connect
-from qmmap import toMongoEngine, connectMongoEngine
+from qmmap import toMongoEngine, connectMongoEngine, mmap
 connect("test")
 
 class qmmap_in(Document):
@@ -72,9 +78,10 @@ for o in qmmap_out.objects:
 
     0 10 20 30 40 50 60 70 80 90
 
-Alternatively, if your processing function is written in a way that converts a mongoengine object to another mongoengine object, simply add the `qmmapify` decorator, passing in the input class:
+Alternatively, if your processing function is written in a way that converts a mongoengine object to another mongoengine object, simply add a `qmmapify` decorator, passing in the input class.  If you want to preserve the mongoengine-to-mongoengine interface of that function, create a second function, and pass that second one to QMmap.  See below, where the second function (`qmmap_func`) with the dectorator simply calls the first.
 
 ```Python
+# demo/demo4_
 import qmmap
 
 class qmmap_in(Document):
@@ -96,15 +103,60 @@ def qmmap_func(qmmap_in_obj):
 ret = qmmap.mmap(qmmap_func, "qmmap_in", "qmmap_out")
 ```
 
-You can then continue to have `func` operate in the "mongoengine" world while passing `qmmap_func` to qmmap.
+You can then continue to have `func` operate in the "mongoengine" world while passing `qmmap_func` to qmmap. (
 
 We can leverage multiple CPU's by specifying the ```multi``` parameter:
 
 ```Python
-ret = mmap(func, "qmmap_in", "qmmap_out", multi=2)
+# demo/demo4_mongoengine_multicore_qmmap.py
+# same as demo3 except for some multicore options specified
+# ...
+ret = mmap(func, "qmmap_in", "qmmap_out", multi=2, sleep=2, reset=True)
 ```
 
-To invoke from the command line, you must pass four required arguments in this order:
+## "init" function
+
+You may optionally pass an "init" function parameter to `qmmap.mmap` (if called from the command line, you give it the function's name, and it must be in the same module as the processing `function`). If specified, this init function will be called at the beginning of every chunk.
+
+Its parameters are
+
+- `source`, a pymongo cursor that iterates over the documents in the input chunk
+- `dest`, a pymongo cursor into the destination collection
+
+### Context variables
+
+If you return a dictionary from the init function, it will be available to every invocation of the processing function, via the variable `qmmap.context`. This is useful for computations that you want to be done only once.
+
+
+## Typical use cases and recommendations
+
+### Collection transformations
+
+In the simplest case, just pass a function that computes the output document given the input document.
+
+### Transformation with filter
+
+As above, but you can return `None` for objects that should not be passed on to the output collection.
+
+Alternately, you can use the `query` parameter to specify a pymongo query, and QMmap will only operate on values satisfying the query.  However, it must do the query twice (once when setting up housekeeping and again when iterating over the chunk), so it's only recommended for queries that can make good use of indexes; otherwise, it's best to implement the logic in the processor function itself.
+
+### Ensure operations on certain documents happen together.
+
+Whatever field you set for the `key` parameter of `mmap`, the housekeeping step will ensure that all documents with the same value the `key` paramter are placed in the same chunk.  (By default, it chunks by primary key.)
+
+### Ensure that operations happen in a specific order.
+
+You can specify an attribute in the `sort` parameter of mmap. If you do, mmap will iterate over each chunk only after having sorted by that parameter.
+
+#### Example: Insertion in timestamp order
+
+Let's say you want to compute a list of diffs over time for a user's account balance given snapshots over time. There are many documents in the input collection that correspond to the same user. It's easier to compute these diffs when you know you're always inserting a new account balance in chronological order.
+
+To best handle that case with QMmap, you will want to ensure that all user shapshots for the same user occur in the same chunk (as chunks may be processed in any order), and that they are operated on in order of timestamp. Therefore, set the `key` parameter as the user id and the `sort` parameter as the time stamp.  Then, your processing function can always assume that it has the snapshots in chronological order, so it can safely compute the diff against the last known snapshot for that user.
+
+## Command line invocation
+
+To invoke from the command line, use `qmcli.py`; you *must* pass four required arguments in this order:
 
 ```
   module                Python module containing the function you wish to
@@ -117,46 +169,48 @@ To invoke from the command line, you must pass four required arguments in this o
                         documents of `module`.`function` to
 ```
 
-Other deviations from the default arguments can be specified as indicated in `qmcli.py --help`.  Importantly, you may draw the settings from a JSON file using `--jsonconfig` or a python module with `pyconfig`. Assuming the file above is in `processors/convert.py`, you could invoke it from the command line as:
+Other deviations from the default arguments can be specified as indicated in `qmcli.py --help`.  Importantly, you may draw the settings from a JSON file using `--jsonconfig` or a python module with `pyconfig`. Assuming the file in the example code above is in `processors/convert.py`, you could invoke it from the command line as:
 
 ```Bash
 qmcli.py --multi=2 processors.convert qmmap_func qmmap_in qmmap_out
 ```
 
+## Example benchmarks
+
 Run ``test.py`` to see multiple CPU's work for real.
 
 ```Python
-run test.py
+python test.py
 ```
 
 ```
 drop qmmap_in, qmmap_out, housekeeping(qmmap_in_qmmap_out)?y
 Generating test data, this may be slow...
 Running mmap...
-time processing: 18.1320679188 seconds
+time processing: 16.4323170185 seconds
 representative output:
 BQZWVQTIEWZWHNERPLCP
 FSLTFLDAYTKHWCHKWTTX
 BRYOCRKDJGTBZCKMMSIG
 ```
 
-On my machine using one process, this took about 18 seconds. Let's try to use all 4 cores:
+On my machine using one process, this took about 16 seconds. Let's try to use all 4 cores:
 
 ```Python
-run test.py 4 --skipdata
+python test.py 4 --skipdata --sleep 1
 ```
 
 ```
 drop qmmap_out, housekeeping(qmmap_in_qmmap_out)?y
 Running mmap...
-time processing: 6.23155999184 seconds
+time processing: 8.48818993568 seconds
 representative output:
 BQZWVQTIEWZWHNERPLCP
 FVPKESQNSFVIHUQQOJCX
 UXSIJIMOOHGBFWGGSENP
 ```
 
-Six seconds - about 3 times faster. Larger data sets should provide even better results; speedup should approach the number of CPU's available.
+Larger data sets should provide even better results; speedup should approach the number of CPU's available.
 
 Multiple separate machines can operate on the same data, as a compute cluster. To accomplish this, we break up the processing into an initialization phase which runs first, then run a process phase on multiple nodes:
 
@@ -207,3 +261,14 @@ PVKUCFRLANQXCMCBQKXC
 10000 succesful operations out of 10000
 ```
 
+## Notes on multi-node runs
+
+Once a job is set up, you can continue to add workers on other nodes by invoking mmap with `--process_only`. One suggested model for doing so (e.g. in a Jenkins workflow) is as follows:
+
+1) Allocate nodes such that the number of executors equals the number of cores on the node.
+
+2) Set up a chain of jobs: first a job runs the initialization state (`qmcli.py` with `--init_only`)
+
+3) That initialization is followed by then two jobs simultaneously: a `--manage_only` job and a spawning of multiple instances of a `--process_only` job (perhaps using the Build Flow plugin if on Jenkins
+
+4) There should be as many `--process_only` jobs as there are executors on the available nodes, which in turn is equal to the number of cores.

--- a/readme.MD
+++ b/readme.MD
@@ -1,10 +1,10 @@
-#qmMap
+#QMmap
 
 ##Distributed MongoDB Map
 
 ###from hiQ Labs (www.hiqlabs.com)
 
-qmMap is a lightweight library that enables asynchronous, parallel processing of MongoDB documents using a simple, map-like interface.
+QMmap is a lightweight library that enables asynchronous, parallel processing of MongoDB documents using a simple, map-like interface.
 
 *The following examples were created in IPython, an excellent tool. Cut and paste these examples into your IPython notebook:*
 
@@ -22,10 +22,11 @@ print map(func, src)
 
     [0, 10, 20, 30, 40, 50, 60, 70, 80, 90]
 
-qmMap provides a similar function, ```mmap```, that operates on MongoDB collections:
+QMmap provides a similar function, ```mmap```, that operates on MongoDB collections:
 
 ```Python
-# assumes mongodb running locally, database named 'test'
+# assumes mongodb running locally, database named 'test', function input is a
+# pymongo object
 import pymongo
 from qmmap import mmap
 
@@ -42,7 +43,7 @@ print list(ret.find())
 ```
     [{u'_id': 0}, {u'_id': 10}, {u'_id': 20}, {u'_id': 30}, {u'_id': 40}, {u'_id': 50}, {u'_id': 60}, {u'_id': 70}, {u'_id': 80}, {u'_id': 90}]
 
-qmMap has helper functions to support mongoengine classes:
+QMmap has helper functions to support mongoengine classes:
 
 ```Python
 from mongoengine import Document, IntField, connect
@@ -71,24 +72,56 @@ for o in qmmap_out.objects:
 
     0 10 20 30 40 50 60 70 80 90
 
+Alternatively, if your processing function is written in a way that converts a mongoengine object to another mongoengine object, simply add the `qmmapify` decorator, passing in the input class:
+
+```Python
+import qmmap
+
+class qmmap_in(Document):
+    num1 = IntField()
+    num2 = IntField()
+
+class qmmap_out(Document):
+    val = IntField()
+
+def func(qmmap_in_obj):
+    output = qmmap_out()
+    output.val = qmmap_in_obj.num1 + qmmap_in_obj.num2
+    return output
+
+@qmmap.qmmapify(qmmap_in)
+def qmmap_func(qmmap_in_obj):
+    return func(qmmap_in_obj)
+
+ret = qmmap.mmap(qmmap_func, "qmmap_in", "qmmap_out")
+```
+
+You can then continue to have `func` operate in the "mongoengine" world while passing `qmmap_func` to qmmap.
+
 We can leverage multiple CPU's by specifying the ```multi``` parameter:
 
 ```Python
 ret = mmap(func, "qmmap_in", "qmmap_out", multi=2)
 ```
 
+To invoke from the command line, you must pass four required arguments in this order:
+
 ```
-WARNING -- can't generate module name. Multiprocessing will be emulated...
+  module                Python module containing the function you wish to
+                        apply to the input collection, e.g. foo.bar[...]
+  function              Function within `module` that you wish to apply to
+                        each member of theinput collection
+  source_col            input/source collection, sent to `module`.`function`
+                        for processing
+  dest_col              output/destination collection to write output
+                        documents of `module`.`function` to
 ```
 
-qmMap doesn't (presently) support multiple CPU's from the command line, so we get a warning.
+Other deviations from the default arguments can be specified as indicated in `qmcli.py --help`.  Importantly, you may draw the settings from a JSON file using `--jsonconfig` or a python module with `pyconfig`. Assuming the file above is in `processors/convert.py`, you could invoke it from the command line as:
 
-
-```Python
-print list(ret.find())
+```Bash
+qmcli.py --multi=2 processors.convert qmmap_func qmmap_in qmmap_out
 ```
-
-    [{u'_id': 10}, {u'_id': 20}, {u'_id': 30}, {u'_id': 40}, {u'_id': 50}, {u'_id': 60}, {u'_id': 70}, {u'_id': 80}, {u'_id': 90}, {u'_id': 100}, {u'_id': 0}]
 
 Run ``test.py`` to see multiple CPU's work for real.
 

--- a/setup.py
+++ b/setup.py
@@ -5,5 +5,5 @@ setup(name='qmmap',
       version='0.001',
       description='Parallel MongoDB Map',
       url='https://github.com/hiqlabs/qmmap/',
-      scripts=[],
+      scripts=["qmmap_worker.py"],
      )

--- a/setup.py
+++ b/setup.py
@@ -5,5 +5,5 @@ setup(name='qmmap',
       version='0.001',
       description='Parallel MongoDB Map',
       url='https://github.com/hiqlabs/qmmap/',
-      scripts=["qmmap_worker.py"],
+      scripts=["qmcli.py"],
      )

--- a/test.py
+++ b/test.py
@@ -24,11 +24,20 @@ def process(source):
     return gd.to_mongo()
 
 def randstring(size):
-    s = ""
-    for i in range(size):
-        s += chr(random.randint(65, 65+25))
-    return s
- 
+    return "".join(chr(random.randint(65, 65+25)) for i in xrange(size))
+
+def make_random_input(num, size):
+    """Randomize an input data set in the qmmap_src collection
+    @num: number of elements
+    @size: size, in characters, of each string in the input
+    """
+    for i in xrange(num):
+        src = qmmap_src()
+        src.s1 = randstring(config.size)
+        src.s2 = randstring(config.size)
+        src.save()
+
+
 if __name__ == "__main__":
     import pymongo, time
     db = pymongo.MongoClient("mongodb://127.0.0.1/test").get_default_database()
@@ -41,11 +50,18 @@ if __name__ == "__main__":
     par.add_argument("--verbose", type=int, default=1)
     par.add_argument("--skipdata", action='store_true')
     par.add_argument("--init_only", action='store_true')
+    par.add_argument("--make_input_only", action='store_true')
     par.add_argument("--process_only", action='store_true')
     par.add_argument("--timeout", type=int, default=120)
     par.add_argument("--sleep", type=int, default=60)
     
     config = par.parse_args()
+
+    if config.make_input_only:
+        if not config.skipdata:
+            qmmap_src.objects.delete()
+        make_random_input(config.num, config.size)
+        sys.exit(0)
 
     if not config.process_only:
         if not config.skipdata:
@@ -55,11 +71,7 @@ if __name__ == "__main__":
                 db.qmmap_src_qmmap_dest.drop()
         
             print "Generating test data, this may be slow..."
-            for i in range(config.num):
-                src = qmmap_src()
-                src.s1 = randstring(config.size)
-                src.s2 = randstring(config.size)
-                src.save()
+            make_random_input(config.num, config.size)
         else:
             if raw_input("drop qmmap_dest, housekeeping(qmmap_src_qmmap_dest)?")[:1] == 'y':
                 db.qmmap_dest.drop()

--- a/test.py
+++ b/test.py
@@ -38,10 +38,12 @@ if __name__ == "__main__":
     par.add_argument("processes", type=int, nargs='?', default=1)
     par.add_argument("size", type=int, nargs='?', default=500)
     par.add_argument("num", type=int, nargs='?', default=10000)
-    par.add_argument("--verbose", type=int, default = 1)
+    par.add_argument("--verbose", type=int, default=1)
     par.add_argument("--skipdata", action='store_true')
     par.add_argument("--init_only", action='store_true')
     par.add_argument("--process_only", action='store_true')
+    par.add_argument("--timeout", type=int, default=120)
+    par.add_argument("--sleep", type=int, default=60)
     
     config = par.parse_args()
 
@@ -65,8 +67,10 @@ if __name__ == "__main__":
     
     print "Running mmap..."
     t = time.time()
-    qmmap.mmap(process, "qmmap_src", "qmmap_dest", init=init, multi=config.processes, 
-                verbose=config.verbose, init_only=config.init_only, process_only=config.process_only)
+    qmmap.mmap(process, "qmmap_src", "qmmap_dest", init=init,
+        multi=config.processes, verbose=config.verbose, init_only=config.init_only,
+        process_only=config.process_only, timeout=config.timeout,
+        sleep=config.sleep)
     print "time processing:", time.time() - t, "seconds"
     print "representative output:"
 #     print list(db.qmmap_dest.find())


### PR DESCRIPTION
Don't merge yet! WIPs will be rebased and some other changes are still in progress.

Summary of changes:

1) Couldn't read from secondary: Set read preference to "secondary preferred" on input collection so that, by default, it can read when pointed at a secondary. (Otherwise it would fail since by default it's not permitted to read from a secondary – thanks Mongo.)

2) Couldn't authenticate to destination DB: Fixed bug that prevented authenticating to destination DB – it needed the destination URI to be passed to connection function. 

3) Started storing process names with housekeeping: Started storing a globally-unique procname identifier with the housekeeping documents so that processing jobs can know if they are colliding with other work, and started having the jobs check for this before writing.

4) Added status report/manage option for Jenkins: Added a "manage only" option to mmap, analogous to the manage functionality in the old PR, which simply reports status and re-opens stale jobs; brought over the "print progress" function from previous PR. This is necessary for running Jenkins jobs.

5) Fixed slow housekeeping setup bug: Fixed a bug where housekeeping setup was taking so long because its .count() call was not obeying the "limit" restriction, which was really slowing it down, as it had to iterate through the whole input collection rather than just verify that there were at least 600 more elements. (It needed with_limit_and_skip=True.)

6) Bulk output operations: Adapted processing jobs (that use housekeeping) to write out their output as one bulk operation of the entire chunk instead of inserting each one as it's finished. 

7) Bulk input operations: Increase batch size on source cursor to the maximum chunk size so reduce the number of lags waiting for DB response while increasing their size. 

8) Host/port lookup bug: Corrected the lookup of host and port from connection URIs – code was using .PORT/.HOST which was returning a default value rather than the actual; should be lowercase.

9) Native python process triggering rather than system calls: Used Python stdlib threading library to spawn subjobs (in non-Jenkins mode), avoiding the need to trigger a bash call and potential interface confusion. commit

10) Added QMmap command-line script, `qmcli.py`. (Addresses #1, #3)

11) Added `reset` parameter to mmap to allow user to drop output collection before operating.

12) Added `sort` parameter to mmap to allow user to specify a key to sort by within each chunk, which ensures operations are performed in that order.

13) Added `chunk_size` to mmap to allow user to specify the chunk size.

14) Allows user to return a dict from the `init` function -- for precomputing values -- which are then available within the `qmmap.context` dict. (Addresses #2)

15) Insertions are now always updates if an `_id` parameter is given.

16) **EDIT** 9 Nov 2016: Chance the CLI query argument parser to use `bson`'s JSON util instead of the python one so it can understand datetimes.